### PR TITLE
MessageParser fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+/out/
+/lib/

--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
 , "main": "lib/Server"
 , "bin": "bin/ircs"
 , "dependencies":
-  { "split": "^0.3.2"
-  , "array-find": "^0.1.1"
+  { "array-find": "^0.1.1"
   , "es6-map": "^0.1.1" }
 , "devDependencies":
   { "6to5": "2.x" }

--- a/src/Message.js
+++ b/src/Message.js
@@ -24,13 +24,6 @@ export default function Message(prefix, command, parameters) {
    * @member {Array.<string>}
    */
   this.parameters = parameters
-
-  if (parameters) {
-    var last = parameters[parameters.length - 1]
-    if (last && last.indexOf(' ') !== -1) {
-      parameters[parameters.length - 1] = ':' + parameters[parameters.length - 1]
-    }
-  }
 }
 
 /**
@@ -39,7 +32,16 @@ export default function Message(prefix, command, parameters) {
  * @return {string} IRC command.
  */
 Message.prototype.toString = function () {
+  let parameters = this.parameters.slice(0)
+  // prefix last parameter by : so it becomes trailing data
+  if (parameters.length) {
+    let last = parameters[parameters.length - 1]
+    if (last && last.indexOf(' ') !== -1) {
+      parameters[parameters.length - 1] = ':' + parameters[parameters.length - 1]
+    }
+  }
+
   return (this.prefix ? ':' + this.prefix + ' ' : '') +
          this.command +
-         (this.parameters ? ' ' + this.parameters.join(' ') : '')
+         (parameters.length ? ' ' + parameters.join(' ') : '')
 }

--- a/test/MessageParser.js
+++ b/test/MessageParser.js
@@ -7,8 +7,8 @@ describe('MessageParser', function () {
     var i = 0
     MessageParser()
       .on('data', function (d) { i++ })
-      .on('close', function () { assert.equal(i, 3), done() })
-      .end('CAP LS\r\nPASS my_password\r\nUSER test_user 0 * :Real Name')
+      .on('finish', function () { assert.equal(i, 3), done() })
+      .end('CAP LS\r\nPASS my_password\r\nUSER test_user 0 * :Real Name\r\n')
   })
 
   it('reads simple incoming commands correctly', function () {

--- a/test/MessageParser.js
+++ b/test/MessageParser.js
@@ -1,0 +1,33 @@
+var assert = require('assert')
+
+describe('MessageParser', function () {
+  var MessageParser = require('../lib/MessageParser')
+
+  it('splits incoming messages into separate commands', function (done) {
+    var i = 0
+    MessageParser()
+      .on('data', function (d) { i++ })
+      .on('close', function () { assert.equal(i, 3), done() })
+      .end('CAP LS\r\nPASS my_password\r\nUSER test_user 0 * :Real Name')
+  })
+
+  it('reads simple incoming commands correctly', function () {
+    var message = MessageParser.prototype.parse('NICK myNickName')
+    assert.equal(message.command, 'NICK')
+    assert.deepEqual(message.parameters, [ 'myNickName' ])
+  })
+
+  it('reads incoming commands with trailing data correctly', function () {
+    var message = MessageParser.prototype.parse('USER test_user 0 * :This trailing data is a long real name')
+    assert.equal(message.command, 'USER')
+    assert.deepEqual(message.parameters, [ 'test_user', '0', '*', 'This trailing data is a long real name' ])
+  })
+
+  it('reads incoming commands with prefixes', function () {
+    var message = MessageParser.prototype.parse(':nick!user@localhost COMMAND parameter :trailing')
+    assert.equal(message.command, 'COMMAND')
+    assert.equal(message.prefix, 'nick!user@localhost')
+    assert.deepEqual(message.parameters, [ 'parameter', 'trailing' ])
+  })
+
+})


### PR DESCRIPTION
Adds basic tests for MessageParser and fixes two bugs:

1. Messages would not prefix their trailing data with `:` if it was changed after instantiation
2. MessageParser would spew some garbage when connections closed after a full message (ending in \r\n)